### PR TITLE
NOISSUE: fix several bugs in aggregate-logs.py + autopep8

### DIFF
--- a/aggregate-logs.py
+++ b/aggregate-logs.py
@@ -68,7 +68,7 @@ for port in range(START_PORT, END_PORT+1):
         """ gopher@"""+hostname+""":go/src/github.com/insolar/insolar/*.log.gz """+node_dir)
 
 run(ZCAT + " " + copy_to_dir + """*/*.log.gz | egrep -n '"level":"(error|fatal|panic)"' """ +
-    """ | sort > """ + copy_to_dir + """all_errors.log""")
+    """ | sort -n > """ + copy_to_dir + """all_errors.log""")
 
 run("""cat """ + copy_to_dir + """all_errors.log """ +
     """ | grep -v "TraceID already set" | grep -v "Failed to process packet" | sort > """ +

--- a/aggregate-logs.py
+++ b/aggregate-logs.py
@@ -67,7 +67,7 @@ for port in range(START_PORT, END_PORT+1):
     run("""scp -o 'StrictHostKeyChecking no' -i ./base-image/id_rsa -P """+str(port) +
         """ gopher@"""+hostname+""":go/src/github.com/insolar/insolar/*.log.gz """+node_dir)
 
-run(ZCAT + " " + copy_to_dir + """*/*.log.gz | egrep -nr '"level":"(error|fatal|panic)"' """ +
+run(ZCAT + " " + copy_to_dir + """*/*.log.gz | egrep -n '"level":"(error|fatal|panic)"' """ +
     """ | sort > """ + copy_to_dir + """all_errors.log""")
 
 run("""cat """ + copy_to_dir + """all_errors.log """ +

--- a/aggregate-logs.py
+++ b/aggregate-logs.py
@@ -9,7 +9,7 @@ END_PORT = 32012
 DEBUG = True
 
 ZCAT = "zcat"
-if os.uname().sysname.lower():
+if os.uname().sysname.lower() == "darwin":
     ZCAT = "gzcat"
 
 


### PR DESCRIPTION
1. gzcat doesn't exist on Linux
2. `sort -n` should be used to sort numbers properly
3. fix egrep arguments