### PR TITLE
INS-3942: add --redeploy-observer flag

### DIFF
--- a/run-test.py
+++ b/run-test.py
@@ -788,7 +788,7 @@ def deploy_observer_deps(path):
            "/tmp/nginx_default.conf")
     ssh(OBSERVER, """sudo bash -c \\"cat /tmp/nginx_default.conf > /etc/nginx/sites-enabled/default && service nginx start\\" """)
 
-def deploy_observer(path):
+def deploy_observer(path, keep_database=False):
     info("deploying observer @ pod "+str(OBSERVER) +
          ", using source code from "+path+"/observer")
     # cleanup after previous deploy, if there was one
@@ -1439,7 +1439,7 @@ if args.skip_all_tests and args.others_path and args.redeploy_observer:
     info("=== Re-deploying observer on running pods, keep_database = "+str(keep_database)+"... ===")
     POD_NODES = k8s_get_pod_nodes()
     wait_until_ssh_is_up_on_pods()
-    deploy_observer(args.others_path)
+    deploy_observer(args.others_path, keep_database = keep_database)
     notify("Observer re-deployed!")
     sys.exit(0)
 

--- a/run-test.py
+++ b/run-test.py
@@ -1396,13 +1396,16 @@ parser.add_argument(
     help='enable debug output')
 parser.add_argument(
     '-s', '--skip-all-tests', action="store_true",
-    help='skip all tests, check only deploy procedure; use with -o and -r to only re-deploy observer')
+    help='skip all tests, check only deploy procedure')
 parser.add_argument(
     '-m', '--minimum-tests', action="store_true",
     help='run minimal required tests set')
 parser.add_argument(
     '-r', '--repeat', metavar='N', type=int, default=1,
-    help='number of times to repeat tests; when -o and -s are used, -r means to only re-deploy observer')
+    help='number of times to repeat tests')
+parser.add_argument(
+    '--redeploy-observer', action="store_true",
+    help='re-deploy observer on running pods; valid only when -o and -s flags are used')
 parser.add_argument(
     '-n', '--namespace', metavar='X', type=str, default="default",
     help='exact k8s namespace to use')
@@ -1447,9 +1450,8 @@ POD_NODES = k8s_get_pod_nodes()
 wait_until_ssh_is_up_on_pods()
 pod_ips = k8s_get_pod_ips()
 
-# When --skip-all-tests and --others-path are used, the -r flag changes
-# it meaning to "only re-deploy observer and do nothing else"
-if args.skip_all_tests and args.others_path and args.repeat:
+if args.skip_all_tests and args.others_path and args.redeploy_observer:
+    info("Re-deploying observer on running pods...")
     deploy_observer(args.others_path)
     notify("Observer re-deployed!")
     sys.exit(0)

--- a/run-test.py
+++ b/run-test.py
@@ -805,8 +805,11 @@ def deploy_observer(path, keep_database=False):
            INSPATH+"/../observer/.artifacts/observer.yaml")
     scp_to(OBSERVER, "/tmp/insolar-jepsen-configs/observerapi.yaml",
            INSPATH+"/../observer/.artifacts/observerapi.yaml")
-    ssh(OBSERVER, "cd "+INSPATH +
-        "/../observer && GO111MODULE=on make migrate && mkdir -p .artifacts")
+    if not keep_database:
+        info("purging observer's database...")
+        ssh(OBSERVER, """echo -e \\"DROP DATABASE observer; CREATE DATABASE observer;\\" | sudo -u postgres psql""")
+        ssh(OBSERVER, "cd "+INSPATH +
+            "/../observer && GO111MODULE=on make migrate && mkdir -p .artifacts")
     # run observer
     ssh(OBSERVER, """tmux new-session -d -s observer \\"cd """+INSPATH +
         """/../observer && ./bin/observer 2>&1 | tee -a observer.log; bash\\" """)

--- a/run-test.py
+++ b/run-test.py
@@ -809,7 +809,7 @@ def deploy_observer(path, keep_database=False):
         info("purging observer's database...")
         ssh(OBSERVER, """echo -e \\"DROP DATABASE observer; CREATE DATABASE observer;\\" | sudo -u postgres psql""")
         ssh(OBSERVER, "cd "+INSPATH +
-            "/../observer && GO111MODULE=on make migrate && mkdir -p .artifacts")
+            "/../observer && GO111MODULE=on make migrate")
     # run observer
     ssh(OBSERVER, """tmux new-session -d -s observer \\"cd """+INSPATH +
         """/../observer && ./bin/observer 2>&1 | tee -a observer.log; bash\\" """)


### PR DESCRIPTION
How to test:

```
# First deploy
./run-test.py --debug -i insolar-jepsen:latest --others-path .. --skip-all-tests
curl localhost:31009/admin/migration/addresses?limit=10

# Re-deploy observer, keeping the database
./run-test.py --debug -i insolar-jepsen:latest --others-path .. --skip-all-tests --redeploy-observer --keep-database true

# Re-deploy observer, purging the database
./run-test.py --debug -i insolar-jepsen:latest --others-path .. --skip-all-tests --redeploy-observer --keep-database false
```
