### PR TITLE
copy all keys in prepare_keys.sh script, we may need any

### DIFF
--- a/prepare_keys.sh
+++ b/prepare_keys.sh
@@ -2,5 +2,5 @@
 
 rm -r /tmp/jepsen-keys || true
 mkdir /tmp/jepsen-keys
-scp -o 'StrictHostKeyChecking no' -i ./base-image/id_rsa -P32001 -r 'gopher@localhost:go/src/github.com/insolar/insolar/scripts/insolard/configs/migration_*_member_keys.json' /tmp/jepsen-keys/
+scp -o 'StrictHostKeyChecking no' -i ./base-image/id_rsa -P32001 -r 'gopher@localhost:go/src/github.com/insolar/insolar/scripts/insolard/configs/*_keys.json' /tmp/jepsen-keys/
 scp -o 'StrictHostKeyChecking no' -i ./base-image/id_rsa -P32001 -r gopher@localhost:go/src/github.com/insolar/insolar/scripts/insolard/bootstrap.yaml /tmp/jepsen-keys/bootstrap_default.yaml


### PR DESCRIPTION
I've stumbled on this while running autotests from scratch